### PR TITLE
[NO-ISSUE] Feature/details view

### DIFF
--- a/NextStats/Views/Base.lproj/Main.storyboard
+++ b/NextStats/Views/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="FsU-Q3-fQG">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.13.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="FsU-Q3-fQG">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.9"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -67,7 +67,6 @@
                                     <outlet property="icon" destination="Kq2-Tc-cir" id="BTK-Lw-SA7"/>
                                     <outlet property="titleLabel" destination="YE6-AA-Rqc" id="QKL-BZ-32E"/>
                                     <outlet property="valueLabel" destination="r1l-Ux-CG7" id="Kym-Pz-0b2"/>
-                                    <segue destination="cMG-lw-Qg2" kind="show" identifier="ShowDetail" id="9Sa-o7-Gah"/>
                                 </connections>
                             </collectionViewCell>
                         </cells>
@@ -94,7 +93,7 @@
         <!--Detail Controller-->
         <scene sceneID="C26-Rw-5HF">
             <objects>
-                <viewController id="cMG-lw-Qg2" customClass="DetailController" customModule="NextStats" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="DetailController" id="cMG-lw-Qg2" customClass="DetailController" customModule="NextStats" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="gzw-Fk-Jai">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/NextStats/Views/DetailController.swift
+++ b/NextStats/Views/DetailController.swift
@@ -13,7 +13,10 @@ class DetailController: UIViewController {
     var widget: Widget?
 
     override func viewDidLoad() {
-        print(self.widget)
         super.viewDidLoad()
+        guard let widget = widget else {
+            return
+        }
+        print("The Widget is: \(widget)")
     }
 }

--- a/NextStats/Views/DetailController.swift
+++ b/NextStats/Views/DetailController.swift
@@ -19,4 +19,8 @@ class DetailController: UIViewController {
         }
         print("The Widget is: \(widget)")
     }
+    
+    static func storyboardIdentifier() -> String {
+        return "DetailController"
+    }
 }

--- a/NextStats/Views/MainController.swift
+++ b/NextStats/Views/MainController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-final class MainController: UICollectionViewController, UICollectionViewDelegateFlowLayout {
+final class MainController: UICollectionViewController {
     private var data = [Widget]()
     private var timer = Timer()
     private var pinned = ApplicationSettings.pinnedWidgets
@@ -30,18 +30,8 @@ final class MainController: UICollectionViewController, UICollectionViewDelegate
         return cell
     }
 
-    fileprivate let sectionInsets = UIEdgeInsets(top: 8.0, left: 8.0, bottom: 8.0, right: 8.0)
-    fileprivate let itemsPerRow: CGFloat = 3
-
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        // 10 Gives us our border around the edges
-        let width = (UIScreen.main.bounds.width - 10) / 3
-
-        if width > 128 {
-            return CGSize(width: 128, height: 128)
-        }
-        return CGSize(width: width, height: width)
-    }
+    private let sectionInsets = UIEdgeInsets(top: 8.0, left: 8.0, bottom: 8.0, right: 8.0)
+    private let itemsPerRow: CGFloat = 3
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "ShowDetail" {
@@ -166,5 +156,17 @@ final class MainController: UICollectionViewController, UICollectionViewDelegate
             print(indexPath)
             alertForCell(indexPath: indexPath)
         }
+    }
+}
+
+extension MainController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        // 10 Gives us our border around the edges
+        let width = (UIScreen.main.bounds.width - 10) / 3
+        
+        if width > 128 {
+            return CGSize(width: 128, height: 128)
+        }
+        return CGSize(width: width, height: width)
     }
 }

--- a/NextStats/Views/MainController.swift
+++ b/NextStats/Views/MainController.swift
@@ -181,4 +181,9 @@ extension MainController: UICollectionViewDelegateFlowLayout {
         }
         return CGSize(width: width, height: width)
     }
+    
+    override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let detailWidget = data[indexPath.row]
+        moveToDetailController(with: detailWidget)
+    }
 }

--- a/NextStats/Views/MainController.swift
+++ b/NextStats/Views/MainController.swift
@@ -8,11 +8,11 @@
 
 import UIKit
 
-class MainController: UICollectionViewController, UICollectionViewDelegateFlowLayout {
-    var data = [Widget]()
-    var timer = Timer()
-    var pinned = ApplicationSettings.pinnedWidgets
-    var refreshControl: UIRefreshControl!
+final class MainController: UICollectionViewController, UICollectionViewDelegateFlowLayout {
+    private var data = [Widget]()
+    private var timer = Timer()
+    private var pinned = ApplicationSettings.pinnedWidgets
+    private var refreshControl: UIRefreshControl!
 
     // MARK: - collectionView
 
@@ -139,7 +139,7 @@ class MainController: UICollectionViewController, UICollectionViewDelegateFlowLa
         })
     }
 
-    func alertForCell(indexPath: IndexPath) {
+    private func alertForCell(indexPath: IndexPath) {
         let cell = self.collectionView?.cellForItem(at: indexPath) as! WidgetCollectionCell
         let widget = self.data[indexPath.row]
         let alert = UIAlertController(title: "Actions", message: "Actions.", preferredStyle: .actionSheet)

--- a/NextStats/Views/MainController.swift
+++ b/NextStats/Views/MainController.swift
@@ -159,6 +159,18 @@ final class MainController: UICollectionViewController {
     }
 }
 
+extension MainController {
+    private func moveToDetailController(with widget: Widget) {
+        guard let detailViewController = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: DetailController.storyboardIdentifier()) as? DetailController else {
+            return
+        }
+        detailViewController.widget = widget
+        DispatchQueue.main.async {
+            self.navigationController?.pushViewController(detailViewController, animated: true)
+        }
+    }
+}
+
 extension MainController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         // 10 Gives us our border around the edges


### PR DESCRIPTION
### Description  
Adding a custom object in prepareForSegue is okay, but unfortunately can lead to a lot of issues when multiple segue types are desired.  
And the segue object in interface builder can be complex to work around and makes custom animations more difficult.  
The standard in iOS is to perform push and presentation logic using private functions and delegate functions like "didSelectRow" or "didSelectItem".  
  

1. I added a static storyboardIdentifier String to the DetailController. This can be improved with protocols. ;)  
2. I removed the segue from storyboard.  
3. I improved compile time slightly by using [static dispatch](https://medium.com/@PavloShadov/https-medium-com-pavloshadov-swift-protocols-magic-of-dynamic-static-methods-dispatches-dfe0e0c85509).  
4. I created a private function to send user to DetailController.  